### PR TITLE
Updated package.json to support React 17 and 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "webpack-dev-server": "^2.11.1"
   },
   "peerDependencies": {
-    "react": "^0.14.6 || 15.x || 16.x"
+    "react": "^0.14.6 || 15.x || 16.x || 17.x || 18.x"
   },
   "dependencies": {
     "object-assign": "*",


### PR DESCRIPTION
When using `react-region-select` in React 17 and 18 projects, there are no major vulnerabilities found. To use the package on these projects, using `--force` is required, and this update to the `package.json` fixes that small inconvenience. 